### PR TITLE
Remote data refresh support

### DIFF
--- a/src/SAFE.Client/SAFE.fs
+++ b/src/SAFE.Client/SAFE.fs
@@ -137,6 +137,18 @@ type RemoteData<'T> =
         | NotStarted
         | Loading None -> None
 
+    /// Transitions to Loading, retaining existing data as needed.
+    ///
+    /// ```
+    /// NotStarted -> Loading None
+    /// Loaded x | Loading x -> Loading (Some x)
+    /// ```
+    member this.StartLoading() =
+        match this with
+        | NotStarted -> Loading None
+        | Loaded data -> Loading(Some data)
+        | Loading x -> Loading x
+
 /// Contains utility functions on the `Remote` type.
 module RemoteData =
     /// Maps `Loaded` to `Some`, everything else to `None`.
@@ -168,3 +180,9 @@ module RemoteData =
 
     /// Like `map` but instead of mapping just the value into another type in the `Loaded` case, it will transform the value into potentially a different case of the `RemoteData<'T>` type.
     let bind binder (remote: RemoteData<'T>) = remote.Bind binder
+
+    /// Transitions to Loading, retaining existing data as needed.
+    /// `Loaded x -> Loading x`;
+    /// `NotStarted -> Loading None`;
+    /// `Loading x -> Loading x`;
+    let startLoading (remote: RemoteData<'T>) = remote.StartLoading


### PR DESCRIPTION
This PR makes a small but important change to the `RemoteData<'T>` type:

`| Loading`

becomes

`| Loading of 'T option`

this is very useful for refresh scenarios, whereby you load data and then need to load it again later. Without this, you "lose" the existing data whilst refreshing, which can cause e.g. flickering on screen. There is the `RefreshableRemoteData` type but it is somewhat limited - it has no built-in functionality such as `map` etc. and is somehow awkward to use. Now, if you just want to load data up-front once, you would have `Loading None` during the load. If you're refreshing and want to keep the current data, then you would put it into `Loading (Some xxx)`.

I've added extra `///` comments to aid this change, and adding some an extra member `IsRefreshing`, and updated the existing members to act appropriately on Loading data e.g. `map`, `defaultValue`, `hasData` etc.

Thoughts?