### PR TITLE
Add a new helper type for  SAFE.Client: `Optimistic`

### DIFF
--- a/src/SAFE.Client/SAFE.fs
+++ b/src/SAFE.Client/SAFE.fs
@@ -189,7 +189,7 @@ module RemoteData =
 
 ///A type which represents optimistic updates. 
 type Optimistic<'T> =
-    | NonExistant
+    | NonExistent
     | Exists of value:'T * prev:'T option
     with
         /// Retrieves the current value

--- a/src/SAFE.Client/SAFE.fs
+++ b/src/SAFE.Client/SAFE.fs
@@ -186,3 +186,23 @@ module RemoteData =
     /// `NotStarted -> Loading None`;
     /// `Loading x -> Loading x`;
     let startLoading (remote: RemoteData<'T>) = remote.StartLoading
+
+///A type which represents optimistic updates. 
+type Optimistic<'a> = {
+    Prev: 'a option
+    Curr: 'a option
+}with
+
+    ///Assign the current value as the now previous value and the passed in value as the new current value
+    member this.Update value =
+        {
+            Curr = Some value
+            Prev = this.Curr
+        }
+
+    ///Rollback to the previous value in the case of a failure
+    member this.Rollback =
+        {
+            Curr = this.Prev
+            Prev = None
+        }

--- a/src/SAFE.Client/SAFE.fs
+++ b/src/SAFE.Client/SAFE.fs
@@ -208,3 +208,45 @@ type Optimistic<'T> = {
             Value = this.Prev
             Prev = None
         }
+
+    /// Maps the underlying optimistic value, when it exists, into another shape.
+    member this.Map (f: 'T -> 'U) =
+        {
+            Value = Option.map f this.Value
+            Prev = Option.map f this.Prev
+        }
+        
+    /// Binds both current and previous values using the provided function
+    member this.Bind (f: 'T -> Optimistic<'U>) =
+        match this.Value with
+        | Some v -> f v  // Just use the result directly
+        | None -> { Value = None; Prev = None }
+        
+    /// Returns the current value as an option
+    member this.AsOption = this.Value
+
+/// Module containing functions for working with Optimistic type
+module Optimistic =
+    /// Creates a new Optimistic value with no history
+    let create value = { Value = Some value; Prev = None }
+    
+    /// Creates an empty Optimistic value
+    let empty = { Value = None; Prev = None }
+    
+    /// Updates the current value, shifting existing value to previous
+    let update value (optimistic: Optimistic<'T>) = optimistic.Update value
+    
+    /// Rolls back to the previous value
+    let rollback (optimistic: Optimistic<'T>) = optimistic.Rollback()
+    
+    /// Maps both current and previous values
+    let map f (optimistic: Optimistic<'T>) = optimistic.Map f
+    
+    /// Binds both current and previous values
+    let bind f (optimistic: Optimistic<'T>) = optimistic.Bind f
+    
+    /// Returns the current value as an option
+    let asOption (optimistic: Optimistic<'T>) = optimistic.AsOption
+    
+    /// Returns the previous value as an option
+    let asPrevOption optimistic = optimistic.Prev

--- a/src/SAFE.Client/SAFE.fs
+++ b/src/SAFE.Client/SAFE.fs
@@ -188,21 +188,23 @@ module RemoteData =
     let startLoading (remote: RemoteData<'T>) = remote.StartLoading
 
 ///A type which represents optimistic updates. 
-type Optimistic<'a> = {
-    Prev: 'a option
-    Curr: 'a option
+type Optimistic<'T> = {
+    /// The previous value, if any
+    Prev: 'T option
+    /// The current value, if any
+    Value: 'T option
 }with
 
-    ///Assign the current value as the now previous value and the passed in value as the new current value
+    /// Updates the current value, shifting the existing current value to previous.
     member this.Update value =
         {
-            Curr = Some value
-            Prev = this.Curr
+            Value = Some value
+            Prev = this.Value
         }
 
-    ///Rollback to the previous value in the case of a failure
-    member this.Rollback =
+    /// Rolls back to the previous value, discarding the current one.
+    member this.Rollback () =
         {
-            Curr = this.Prev
+            Value = this.Prev
             Prev = None
         }


### PR DESCRIPTION
supports frontend development.

what changed?: add new helper client types for optimistic update
why?: aid in front end development

implements #11 